### PR TITLE
xmlsec 1.3.17

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/lxml-feedstock/pr17/1d998a6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - xmlsec
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -vvv tests -n 1
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ requirements:
   run:
     - python
     - lxml >=3.8.0,!=4.7.0
+    - libxmlsec1 >=1.2.33
+    - libxml2 >=2.9.1
 
 test:
   source_files:
@@ -40,10 +42,10 @@ test:
     - xmlsec
   commands:
     - pip check
-    - pytest -vvv tests -n 1
+    - pytest -vvv tests
   requires:
     - pip
-    - pytest
+    - pytest <7
 
 about:
   home: https://github.com/mehcode/python-xmlsec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
+  # libxmlsec1 is not in the main channel for Windows:
+  skip: true  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,49 @@
 {% set name = "xmlsec" %}
-{% set version = "1.3.16" %}
+{% set version = "1.3.17" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2b6c70544c6d1d4ca006aaa314958e0ef3514dc81fffde1b23f2ec41a5791f9d
+  url: https://github.com/xmlsec/python-xmlsec/archive/refs/tags/1.3.17.tar.gz
+  sha256: 71967b9fbde59690d7e1a6b37d79f30e006d1fd3060b2a3e09e6472f454f4a99
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [win or py<35]
+  skip: true  # [py<39]
 
 requirements:
   build:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
+    - pkg-config
   host:
     - pip
     - python
-    - setuptools >=42
+    - setuptools >=80.9.0
     - wheel
     - setuptools_scm >=3.4
     - toml
     - pkgconfig >=1.5.1
-    - lxml >=3.8,!=4.7.0
+    # Used the same as in the requirements.txt
+    - lxml ==6.0.2
+    # From readme -> https://github.com/xmlsec/python-xmlsec/blob/1.3.17/README.md#requirements
     - libxml2 >=2.9.1
     - libxmlsec1 >=1.2.33
   run:
     - python
-    - lxml >=3.8.0,!=4.7.0
-    - libxmlsec1 >=1.2.33
-    - libxml2 >=2.9.1
+    # https://github.com/xmlsec/python-xmlsec/blob/master/requirements.txt#L1
+    - lxml ==6.0.2
 
+{% set ignore_tests = "" %}
+# Segmentation fault on line 24 test_constants.py
+# assert str(transform) == f'{transform.name}, {transform.href}'
+{% set ignore_tests = " --ignore=tests/test_constants.py" %}  # [osx]
+# Segmentation fault on line 50 tests/test_ds.py
+# sign = xmlsec.template.create(root, consts.TransformExclC14N, consts.TransformRsaSha1, 'Id')
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_ds.py" %}  # [osx]
 test:
   source_files:
     - tests
@@ -42,10 +51,10 @@ test:
     - xmlsec
   commands:
     - pip check
-    - pytest -vvv tests
+    - pytest -vvv tests {{ ignore_tests }}
   requires:
     - pip
-    - pytest <7
+    - pytest >=8.4.1
 
 about:
   home: https://github.com/mehcode/python-xmlsec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools_scm >=3.4
     - toml
     - pkgconfig >=1.5.1
-    # Used the same as in the requirements.txt
+    # Used the same as in the requirements.txt and it was used for tests in the upstream -> https://github.com/xmlsec/python-xmlsec/actions/runs/19269549253/job/55093915102#step:5:21
     - lxml ==6.0.2
     # From readme -> https://github.com/xmlsec/python-xmlsec/blob/1.3.17/README.md#requirements
     - libxml2 >=2.9.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,48 +1,49 @@
 {% set name = "xmlsec" %}
-{% set version = "1.3.14" %}
+{% set version = "1.3.16" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 934f804f2f895bcdb86f1eaee236b661013560ee69ec108d29cdd6e5f292a2d9
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2b6c70544c6d1d4ca006aaa314958e0ef3514dc81fffde1b23f2ec41a5791f9d
 
 build:
   number: 0
-  # Skip s390x because of missing libxmlsec1, libgpg-error and libgcrypt
-  skip: true  # [(linux and s390x) or win or py<35]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [win or py<35]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - pkg-config
   host:
-    - python
-    - libxml2 {{ libxml2 }}
-    - libxmlsec1 1.3.5
-    - lxml 5.2.1
     - pip
-    - pkgconfig
-    - setuptools
-    - setuptools_scm
-    - toml
+    - python
+    - setuptools >=42
     - wheel
+    - setuptools_scm >=3.4
+    - toml
+    - pkgconfig >=1.5.1
+    - lxml >=3.8,!=4.7.0
+    - libxml2 >=2.9.1
+    - libxmlsec1 >=1.2.33
   run:
     - python
-    - lxml >=3.8.0
+    - lxml >=3.8.0,!=4.7.0
 
 test:
+  source_files:
+    - tests
   imports:
     - xmlsec
-  requires:
-    - pip
   commands:
     - pip check
-    # Check that the correct version is reported by pip
-    - "pip list --format json | grep '{\"name\": \"xmlsec\", \"version\": \"{{ version }}\"}'"
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/mehcode/python-xmlsec
@@ -52,5 +53,9 @@ about:
   summary: Python bindings for the XML Security Library (XMLSec).
   description: |
     Python bindings for the XML Security Library (XMLSec).
-  doc_url: https://xmlsec.readthedocs.io/
+  doc_url: https://xmlsec.readthedocs.io
   dev_url: https://github.com/mehcode/python-xmlsec
+
+extra:
+  skip-lints:
+    - host_section_needs_exact_pinnings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     # https://github.com/xmlsec/python-xmlsec/blob/master/requirements.txt#L1
     - lxml ==6.0.2
 
+# Issue created: https://github.com/xmlsec/python-xmlsec/issues/400
 {% set ignore_tests = "" %}
 # Segmentation fault on line 24 test_constants.py
 # assert str(transform) == f'{transform.name}, {transform.href}'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<39]
-  # libxmlsec1 is not in the main channel for Windows:
+  # libxmlsec1 is not in the main channel for Windows
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
xmlsec 1.3.17

**Destination channel:** Defaults

### Links

- [PKG-10574]
- dev_url:        https://github.com/mehcode/python-xmlsec/tree/1.3.16
- conda_forge:    https://github.com/conda-forge/xmlsec-feedstock
- pypi:           https://pypi.org/project/xmlsec/1.3.16
- pypi inspector: https://inspector.pypi.io/project/xmlsec/1.3.16

### Explanation of changes:

- new version number
- skipped tests with segfaults on osx


[PKG-10574]: https://anaconda.atlassian.net/browse/PKG-10574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ