### PR TITLE
xmlsec 1.3.17

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/lxml-feedstock/pr19/5fee68a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xmlsec" %}
-{% set version = "1.3.14" %}
+{% set version = "1.3.17" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 934f804f2f895bcdb86f1eaee236b661013560ee69ec108d29cdd6e5f292a2d9
+  sha256: f3fac9ae679f66585925cc00c5f6839ae36c1d03157619571dee18acc05b9c01
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,17 +22,17 @@ requirements:
   host:
     - python
     - libxml2 {{ libxml2 }}
-    - libxmlsec1
-    - lxml
+    - libxmlsec1 1.3.5
+    - lxml 6.0.2
     - pip
-    - pkgconfig
-    - setuptools
-    - setuptools_scm
+    - pkgconfig >=1.5.1
+    - setuptools 80.9.0
+    - setuptools_scm >=3.4
     - toml
     - wheel
   run:
     - python
-    - lxml >=3.8.0
+    - lxml >=6.0.2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,19 +11,19 @@ source:
 
 build:
   number: 0
-  # Skip s390x because of missing libxmlsec1, libgpg-error and libgcrypt
-  skip: true  # [(linux and s390x) or win or py<35]
+  skip: true  # [win or py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c')}}
     - pkg-config
   host:
     - python
     - libxml2 {{ libxml2 }}
-    - libxmlsec1 1.3.5
-    - lxml 5.2.1
+    - libxmlsec1
+    - lxml
     - pip
     - pkgconfig
     - setuptools
@@ -45,7 +45,7 @@ test:
     - "pip list --format json | grep '{\"name\": \"xmlsec\", \"version\": \"{{ version }}\"}'"
 
 about:
-  home: https://github.com/mehcode/python-xmlsec
+  home: https://github.com/xmlsec/python-xmlsec
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -53,4 +53,4 @@ about:
   description: |
     Python bindings for the XML Security Library (XMLSec).
   doc_url: https://xmlsec.readthedocs.io/
-  dev_url: https://github.com/mehcode/python-xmlsec
+  dev_url: https://github.com/xmlsec/python-xmlsec


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-12170](https://anaconda.atlassian.net/browse/PKG-12170)
- [Upstream repository](https://github.com/xmlsec/python-xmlsec/tree/1.3.17)
- [Upstream changelog/diff](https://github.com/xmlsec/python-xmlsec/releases)

### Explanation of changes:

- Bump version number
- Build python 3.14 version


[PKG-12170]: https://anaconda.atlassian.net/browse/PKG-12170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ